### PR TITLE
fix:修复package.json文件中main字段入口文件错误的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "registry": "https://registry.npmjs.org/",
     "access": "public"
   },
-  "main": "lib/js",
+  "main": "src/index.ts",
   "scripts": {
     "build-docs": "npx typedoc --out docs/api --excludeNotExported --module commonjs --mode file src",
     "start": "react-native start",


### PR DESCRIPTION
# Summary
closed：#30
- 修复package.json文件中main字段入口文件错误的问题

## Test Plan
修复前报错如下：
![image](https://github.com/user-attachments/assets/66769fad-632c-413f-a205-b7cb41c5aae4)
![image](https://github.com/user-attachments/assets/a60b870d-7254-4567-9d56-463134d431cc)
修复后正常显示

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
