### PR TITLE
feat:新增设置坐标系类型接口，默认是GCJ02坐标系

### DIFF
--- a/harmony/amap_geolocation/src/main/ets/AMapGeolocationModule.ts
+++ b/harmony/amap_geolocation/src/main/ets/AMapGeolocationModule.ts
@@ -61,7 +61,7 @@ export class AMapGeolocationModule extends TurboModule implements IAMapLocationL
       locatingWithReGeocode: true,
       distanceInterval: 0,
       reGeocodeLanguage: AMapLocationReGeocodeLanguage.Chinese,
-      isOffset: false
+      isOffset: true
     }
   }
   onLocationChanged(location: AMapLocation): void {
@@ -245,6 +245,12 @@ export class AMapGeolocationModule extends TurboModule implements IAMapLocationL
   setAllowsBackgroundLocationUpdates(isAllow: boolean): void {
     if (this.options != null) {
       this.options.allowsBackgroundLocationUpdates = isAllow;
+    }
+  }
+
+  setOffsetValue(isOffset:boolean){
+    if (this.options != null) {
+      this.options.isOffset = isOffset;
     }
   }
 

--- a/src/NativeRNAMapGeolocation.ts
+++ b/src/NativeRNAMapGeolocation.ts
@@ -66,6 +66,8 @@ export interface Spec extends TurboModule {
 
 	setOnceLocation(onceLocation: boolean): void;
 
+	setOffsetValue(isOffset: boolean): void;
+
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>("RNAMapGeolocation");

--- a/src/amap-geolocation.ts
+++ b/src/amap-geolocation.ts
@@ -54,6 +54,15 @@ export function setOnceLocation(isOnceLocation: boolean) {
 }
 
 /**
+ * 设置坐标系种类，true为高德坐标系，false为系统（WGS84）坐标系
+ *
+ * @default true
+ */
+export function setOffsetValue(isOffset: boolean) {
+  AMapGeolocation.setOffsetValue(isOffset);
+}
+
+/**
  * 设置是否返回地址信息，默认返回地址信息
  *
  * GPS 定位时也可以返回地址信息，但需要网络通畅，第一次有可能没有地址信息返回。


### PR DESCRIPTION
# Summary

- feat:新增设置坐标系类型接口，默认是GCJ02坐标系。从而解决默认走WGS84坐标系导致拿到的经纬度坐标在高德平台中定位和实际位置有偏差的问题
- close ：#33

## Test Plan
1、运行定位库demo，点击获取当前位置
![image](https://github.com/user-attachments/assets/e9fda8ff-2d1d-4dc5-834e-ae356f3b138b)
2、将获取到的经纬度放到高德坐标拾取器上：
https://lbs.amap.com/tools/picker
3、得到的坐标位置和实际的位置相同

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
